### PR TITLE
#43 - edit button clipping on hover 

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -71,6 +71,7 @@ class About extends Component {
 	render() {
 		const { layerOn } = this.state;
 		const { renderControls, about } = this.props;
+		const btnStyle = { margin: '.2em' };
 		const renderButton = renderControls ? (
 			<Header>
 				<Box flex={true}
@@ -78,6 +79,7 @@ class About extends Component {
 					direction='row'
 					responsive={false}>
 						<Button icon={<Edit />}
+							style={btnStyle} 
 							label='Edit'
 							primary={true}
 							onClick={() => this._openEdit()} />


### PR DESCRIPTION
In About.js - Fixed clipping on hover for 'Edit' button by adding margin of .2em to it

Resolves #43